### PR TITLE
Explicitly use array from boost namespace

### DIFF
--- a/src/net.cpp
+++ b/src/net.cpp
@@ -57,7 +57,7 @@ static bool vfLimited[NET_MAX] = {};
 static CNode* pnodeLocalHost = NULL;
 CAddress addrSeenByPeer(CService("0.0.0.0", 0), nLocalServices);
 uint64_t nLocalHostNonce = 0;
-array<int, THREAD_MAX> vnThreadsRunning;
+boost::array<int, THREAD_MAX> vnThreadsRunning;
 static std::vector<SOCKET> vhListenSocket;
 CAddrMan addrman;
 


### PR DESCRIPTION
boost and std namespaces both define array.
Use boost::array to be explicit to avoid ambiguity.